### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,16 +225,19 @@ public static func TestClass() {
 struct ClassA : Red::IScriptable
 {
     RTTI_IMPL_TYPEINFO(ClassA);
+    RTTI_IMPL_ALLOCATOR();
 };
 
 struct ClassB : ClassA
 {
     RTTI_IMPL_TYPEINFO(ClassB);
+    RTTI_IMPL_ALLOCATOR();
 };
 
 struct ClassC : ClassB
 {
     RTTI_IMPL_TYPEINFO(ClassC);
+    RTTI_IMPL_ALLOCATOR();
 };
 
 RTTI_DEFINE_CLASS(ClassA, "A", {


### PR DESCRIPTION
Add missing allocator declarations when describing class inheritance. It is misleading for new users, without the allocator compilation fails.