### PR TITLE
Add methods to test whether a class/global function is defined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,15 @@ Red::CallVirtual(system, "GetLocalPlayerControlledGameObject", player);
 
 // player.Revive(100.0)
 Red::CallVirtual(player, "Revive", 100.0f);
+
+```
+
+Whether a class / global function is defined in RTTI system? 
+> It can be used to test if another mod is present or not, when it defines new 
+> classes / global functions.
+```cpp
+bool hasRedFileSystem = Red::HasClass("FileSystem");
+bool hasRedData = Red::Detail::HasGlobalFunction("ParseJson");
 ```
 
 ## Accessing game systems

--- a/include/Red/TypeInfo/Invocation.hpp
+++ b/include/Red/TypeInfo/Invocation.hpp
@@ -224,6 +224,10 @@ inline CBaseFunction* GetGlobalFunction(CName aName)
 {
     return CRTTISystem::Get()->GetFunction(aName);
 }
+
+inline bool HasGlobalFunction(CName aName) {
+    return CRTTISystem::Get()->GetFunction(aName) != nullptr;
+}
 }
 
 template<typename... Args>

--- a/include/Red/TypeInfo/Resolving.hpp
+++ b/include/Red/TypeInfo/Resolving.hpp
@@ -415,6 +415,12 @@ inline CClass* GetClass(CName aTypeName)
     return reinterpret_cast<CClass*>(type);
 }
 
+inline bool HasClass(CName aTypeName) {
+    auto type = CRTTISystem::Get()->GetType(aTypeName);
+
+    return type && type->GetType() == ERTTIType::Class;
+}
+
 template<CName AType>
 inline CEnum* GetEnum() noexcept
 {


### PR DESCRIPTION
Feature to somehow replicate `@if(ModuleExists("ModName"))` from redscript:
- add `bool Red::HasClass(CName)`.
- add `bool Red::Detail::HasGlobalFunction(CName)`.
- update README for usage.

Code is cleaner this way instead of writing/repeating implementation.